### PR TITLE
Automate setup in dev environments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,11 +33,7 @@ static/main.min.js
 static/wait.min.js
 
 # Python package folders required for AppEngine
-flask/
-werkzeug/
-jinja2/
-markupsafe/
-itsdangerous.py
+lib
 
 # Scratch work files
 templates/main-scratch.html

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -144,6 +144,7 @@ module.exports = function (grunt) {
    */
 
    grunt.registerTask('default', ['watch']);
+   grunt.registerTask('make', ['concat', 'uglify', 'less']);
 
    // On watch events configure jshint:all to only run on changed file
    grunt.event.on('watch', function(action, filepath) {

--- a/README.md
+++ b/README.md
@@ -71,12 +71,14 @@ to find the heading).
 6. Install [Node.js](https://nodejs.org/en/download/) if you haven't already. Run ```npm install``` to install
 Node dependencies.
 
-7. In a separate terminal window, but in the Netskrafl directory, run ```grunt```.
-Note that some release files, i.e. ```*.css``` and ```*.min.js``` are only created when
-the corresponding source files, i.e. ```*.less``` and ```*.js```, are modified. To trigger an initial build,
-you can```touch static/*.less static/js/*.js```
+7. In a separate terminal window, but in the Netskrafl directory, run ```grunt make```. Then run ```grunt```
+to start watching changes of js and css files.
 
 8. Run either ```runserver.bat``` or ```runserver.sh```.
+
+#### Alternatively
+Run ./setup-dev.sh (tested on Debian based Linux and OS X).
+
 
 ### Original Author
 Vilhjálmur Þorsteinsson, Reykjavík, Iceland.

--- a/generate-secret.py
+++ b/generate-secret.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python
+from __future__ import print_function
+import os
+import sys
+
+file_path="resources/secret_key.bin"
+
+def generate():
+    print("Generating session token, using os.urandom")
+    bytes=os.urandom(64)
+    with open(file_path, "wb") as f:
+        f.write(bytes)
+
+def read():
+    print("Contents of {}".format(file_path))
+    with open(file_path, "rb") as f:
+        bytes = f.read()
+        print(bytes.encode('base64'))
+
+if len(sys.argv) > 1 and sys.argv[1] == "read":
+    read()
+else:
+    generate()
+

--- a/setup-dev.sh
+++ b/setup-dev.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+set -e
+
+#######################################
+# Run without arguments to set up the dev env:
+#  - Symlink site packages to ./lib/
+#  - Checks for dependencies
+#  - Installs python requirements
+#  - Installs node requirements
+#  - Builds dawg files
+#  - Generates flask secret
+#  - Generates css and js
+#
+# Run with <setup-dev.sh> tmux to start
+# the server and grunt in a tmux session
+
+if [ "$1" == "tmux" ]; then
+    tmux new-session -d 'grunt watch' \; split-window -h './runserver.sh; read -p "Press [Enter] to continue..."' \; attach
+    exit 0
+fi
+
+echo "Checking initial dependencies..."
+type python >/dev/null 2>&1 || { echo >&2 " - python is missing"; exit 1; }
+type pip >/dev/null 2>&1 || { echo >&2 " - pip is missing"; exit 1; }
+type npm >/dev/null 2>&1 || { echo >&2 " - npm (node.js) is missing"; exit 1; }
+type node >/dev/null 2>&1 || { echo >&2 " - node is missing - you may need to do 'ln -s /usr/bin/nodejs /usr/bin/node'"; exit 1; }
+type grunt >/dev/null 2>&1 || { echo >&2 " - grunt is missing - run 'npm install grunt -g grunt-cli'"; exit 1; }
+type dev_appserver.py >/dev/null 2>&1 || { echo >&2 " - GAE for python is missing. https://cloud.google.com/appengine/downloads"; exit 1; }
+
+python - <<EOF
+import sys
+if sys.version_info.major == 2 and sys.version_info.minor == 7:
+    sys.exit(0)
+else:
+    print("Unsupported version of Python. Supported: 2.7.*")
+    sys.exit(1)
+EOF
+
+echo "Symlinking site-packages to ./lib"
+sitepackages=`python -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())"`
+ln -fs $sitepackages lib
+
+echo "Installing python requirements in the current virtualenv..."
+pip install -r requirements.txt
+
+echo "Installing node requirements..."
+npm install
+
+if [[ -f resources/algeng.dawg.pickle && -f resources/ordalisti.dawg.pickle ]]; then
+    echo "Pickle files available"
+else
+    echo "Some pickle files not available, running dawgbuilder..."
+    python dawgbuilder.py
+fi
+
+echo "Creating secret file..."
+if [ -f resources/secret_key.bin ]; then
+    echo "Secret file already exists"
+else
+    python generate-secret.py
+fi
+
+echo "Generated resource files:"
+git clean --dry-run -X resources | awk '{ print $3 }'
+
+echo "Generate css and js"
+grunt make
+
+echo "Ready. Next steps:"
+echo "------------------"
+echo "Run: grunt watch"
+echo "Run: runserver.sh"
+echo "  or"
+echo "Run: setup-dev.sh tmux"
+


### PR DESCRIPTION
- Add setup-dev.sh which sets the whole dev environment up
  or reports if there are unmet dependencies
- Update the gruntfile to include the `make` command, which builds
  js and css for the first time. The `watch` command doesn't do
  an initial build
- Add generate-secret.py, a script for creating Flask secrets.
  (Needs review if it's to be used in production.)
- Update the README accordingly

